### PR TITLE
Fix Version Checker and Images

### DIFF
--- a/src/server/main.lua
+++ b/src/server/main.lua
@@ -92,14 +92,22 @@ end
 
 CreateThread(function()
     local name = "[^ictrophies^7]"
-    local checkVersion = function(error, latestVersion, headers)
+    
+    local checkVersion = function(error, latestVersion, headers)     
         local currentVersion = version
+        currentVersion = string.gsub(currentVersion, "^%s*(.-)%s*$", "%1")
+        latestVersion = string.gsub(latestVersion, "^%s*(.-)%s*$", "%1")
         if currentVersion ~= latestVersion then
             print(name .. " ^1is outdated.\nCurrent version: ^8" .. currentVersion .. "\nNewest version: ^2" .. latestVersion .. "\n^3Update^7: https://github.com/IceClusters/ictrophies")
+        else
+            print(name .. " ^2is up to date.")
         end
     end
+
+    -- Perform the HTTP request to check the latest version
     PerformHttpRequest("https://raw.githubusercontent.com/IceClusters/IceVersions/develop/ictrophies.version", checkVersion, "GET")
 end)
+
 
 exports('NewTrophy', NewTrophy)
 

--- a/src/server/main.lua
+++ b/src/server/main.lua
@@ -94,12 +94,8 @@ CreateThread(function()
     local name = "[^ictrophies^7]"
     local checkVersion = function(error, latestVersion, headers)
         local currentVersion = version
-        if currentVersion < latestVersion then
+        if currentVersion ~= latestVersion then
             print(name .. " ^1is outdated.\nCurrent version: ^8" .. currentVersion .. "\nNewest version: ^2" .. latestVersion .. "\n^3Update^7: https://github.com/IceClusters/ictrophies")
-        elseif currentVersion > latestVersion then
-            print(name .. " has skipped the latest version ^2" .. latestVersion .. " Either Github is offline or the version file has been changed")
-        else
-            print(name .. " is updated.")
         end
     end
     PerformHttpRequest("https://raw.githubusercontent.com/IceClusters/IceVersions/develop/ictrophies.version", checkVersion, "GET")

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -74,20 +74,20 @@
                 <div class="section__friends animate__zoomIn animate__animated" style="animation-delay: 1s;">
                     <div class="container__style badges">
                         <div class="row__badges">
-                            <div class="column">
-                                <div class="badges__icons"><img src="https://i.imgur.com/eay4WBv.png"></div>
+                          <div class="column">
+                                <div class="badges__icons"><img src="https://i.ibb.co/ZVQR1fP/low.png"></div>
                                 <div class="text__style" id="badge0">20</div>
                             </div>
                             <div class="column">
-                                <div class="badges__icons"><img src="https://i.imgur.com/Wotxh7E.png"></div>
+                                <div class="badges__icons"><img src="https://i.ibb.co/L0jRxbP/medium.png"></div>
                                 <div class="text__style" id="badge1">10</div>
                             </div>
                             <div class="column">
-                                <div class="badges__icons"><img src="https://i.imgur.com/LZH4HMl.png"></div>
+                                <div class="badges__icons"><img src="https://i.ibb.co/qNyR69r/hard.png"></div>
                                 <div class="text__style" id="badge2">5</div>
                             </div>
                             <div class="column">
-                                <div class="badges__icons"><img src="https://i.imgur.com/a0yuCxN.png"></div>
+                                <div class="badges__icons"><img src="https://i.ibb.co/5vWxv6D/master.png"></div>
                                 <div class="text__style" id="badge3">1</div>
                             </div>
                         </div>

--- a/src/ui/js/app.js
+++ b/src/ui/js/app.js
@@ -3,12 +3,11 @@ let exploding = false;
 let isOpen = false;
 
 const trophiesImage = [
-    "https://i.imgur.com/eay4WBv.png",
-    "https://i.imgur.com/Wotxh7E.png",
-    "https://i.imgur.com/LZH4HMl.png",
-    "https://i.imgur.com/a0yuCxN.png"
+    "<https://i.ibb.co/ZVQR1fP/low.png>",
+    "<https://i.ibb.co/L0jRxbP/medium.png>",
+    "<https://i.ibb.co/qNyR69r/hard.png>",
+    "<https://i.ibb.co/5vWxv6D/master.png>"
 ]
-
 const defaults = {
     particleCount: 500,
     spread: 80,


### PR DESCRIPTION
Version returned "outdated" although was most updated version.
This is caused because of a space in the https://raw.githubusercontent.com/IceClusters/IceVersions/develop/ictrophies.version
Image:
![image](https://github.com/user-attachments/assets/49526167-8522-40c7-929b-9a76d84ccd28)
Fixed it by automatically removing white spaces

Because of Imgur updates, FiveM resources cannot view the images no more, I changed the images to work with ibb.co instead
![image](https://github.com/user-attachments/assets/4dc4ae15-a84f-4bf4-96b8-0444d12d1572)
